### PR TITLE
fix: Add new missing optionnal package for Wordpress

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ wordpress__default_packages:
   - php-curl
   - php-xml
   - php-mbstring
+  - php-imagick
   - php-zip
 
 wordpress__db_packages:


### PR DESCRIPTION
ImageMagick php package was missing